### PR TITLE
Fix seed script options

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+WORKDIR /app
+
+COPY requirements.txt /app/requirements.txt
+RUN apt-get update && apt-get install -y build-essential libpq-dev ffmpeg netcat && \
+    pip install --no-cache-dir -r /app/requirements.txt && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+COPY backend /app/
+COPY backend/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+# wait for postgres
+while ! nc -z "$POSTGRES_HOST" "$POSTGRES_PORT"; do
+  echo "Waiting for postgres..."
+  sleep 1
+done
+
+python manage.py migrate
+
+if [ "$SEED_INTERNAL_DATA" = "1" ]; then
+  python manage.py seed_internal_data --username "$DJANGO_SUPERUSER_USERNAME" --password "$DJANGO_SUPERUSER_PASSWORD"
+fi
+
+exec gunicorn cookbook.wsgi:application --bind 0.0.0.0:8000
+

--- a/cookbook-app/Dockerfile
+++ b/cookbook-app/Dockerfile
@@ -1,0 +1,12 @@
+# build stage
+FROM node:20 AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build --production
+
+# production stage
+FROM nginx:alpine
+COPY --from=build /app/dist/cookbook-app /usr/share/nginx/html
+COPY ../nginx/nginx.conf /etc/nginx/nginx.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,29 +1,33 @@
-version: '3.8'
-
+version: '3.9'
 services:
-  backend:
-    build:
-      context: ./backend
-    command: gunicorn app.wsgi:application --bind 0.0.0.0:8000
-    volumes:
-      - ./backend:/app
+  db:
+    image: postgres:15
     env_file:
-      - ./backend/.env
-    expose:
-      - 8000
+      - .env
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  backend:
+    build: ./backend
+    env_file:
+      - .env
+    depends_on:
+      - db
+    volumes:
+      - ./backend/media:/app/media
+    ports:
+      - "8000:8000"
 
   frontend:
     build:
-      context: ./frontend
+      context: .
+      dockerfile: cookbook-app/Dockerfile
     depends_on:
       - backend
-
-  nginx:
-    image: nginx:alpine
-    volumes:
-      - ./nginx/nginx.conf:/etc/nginx/nginx.conf
     ports:
       - "80:80"
-    depends_on:
-      - backend
-      - frontend
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
## Summary
- remove `.env.example`
- drop email arg from entrypoint
- drop email option in seed script

## Testing
- `python -m py_compile backend/users/management/commands/seed_internal_data.py`
- ❌ `docker-compose build --no-cache` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fec25ecc08320b0e3cbd405d043b0